### PR TITLE
remove dependency on linux/wireless.h

### DIFF
--- a/hcxdumptool.c
+++ b/hcxdumptool.c
@@ -23,8 +23,7 @@
 #include <net/if.h>
 #include <arpa/inet.h>
 #include <net/ethernet.h>
-#include <linux/if_packet.h>
-#include <linux/wireless.h>
+#include <netpacket/packet.h>
 #include <pthread.h>
 
 #ifdef DOGPIOSUPPORT
@@ -37,6 +36,7 @@
 #include "include/pcap.c"
 #include "include/strings.c"
 #include "include/hashops.c"
+#include "wireless-lite.h"
 
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define BIG_ENDIAN_HOST

--- a/wireless-lite.h
+++ b/wireless-lite.h
@@ -1,0 +1,80 @@
+#ifndef WIRELESS_LITE_H
+#define WIRELESS_LITE_H
+
+/* cleaned up from linux/wireless.h */
+
+#include <net/if.h>
+
+#define SIOCSIWFREQ 0x8B04
+#define SIOCSIWMODE 0x8B06
+#define SIOCGIWMODE 0x8B07
+#define SIOCGIWNAME 0x8B01
+
+#define IW_FREQ_FIXED 0x01
+
+#define IW_MODE_AUTO 0
+#define IW_MODE_ADHOC 1
+#define IW_MODE_INFRA 2
+#define IW_MODE_MASTER 3
+#define IW_MODE_REPEAT 4
+#define IW_MODE_SECOND 5
+#define IW_MODE_MONITOR 6
+#define IW_MODE_MESH 7
+
+struct iw_quality {
+	unsigned char qual;
+	unsigned char level;
+	unsigned char noise;
+	unsigned char updated;
+};
+
+struct iw_param {
+	int value;
+	unsigned char fixed;
+	unsigned char disabled;
+	unsigned short flags;
+};
+
+struct iw_point {
+	void *pointer;
+	unsigned short length;
+	unsigned short flags;
+};
+
+struct iw_freq {
+	int m;
+	short e;
+	unsigned char i;
+	unsigned char flags;
+};
+
+union iwreq_data {
+	char name[IFNAMSIZ];
+	struct iw_point	essid;
+	struct iw_param	nwid;
+	struct iw_freq	freq;
+	struct iw_param	sens;
+	struct iw_param	bitrate;
+	struct iw_param	txpower;
+	struct iw_param	rts;
+	struct iw_param	frag;
+	unsigned mode;
+	struct iw_param	retry;
+	struct iw_point	encoding;
+	struct iw_param	power;
+	struct iw_quality qual;
+	struct sockaddr	ap_addr;
+	struct sockaddr	addr;
+	struct iw_param	param;
+	struct iw_point	data;
+};
+
+struct	iwreq {
+	union {
+		char ifrn_name[IFNAMSIZ];
+	} ifr_ifrn;
+	union iwreq_data u;
+};
+
+#endif
+


### PR DESCRIPTION
kernel headers are broken for use in userspace, because the types
defined by them clash with libc headers.
i made a small wireless_lite.h which contains the important bits
and pieces in a clean way.

fixes build on musl libc.
these were the errors:
```
gcc -std=gnu99 -O3 -Wall -Wextra -o hcxdumptool hcxdumptool.c -lrt -lpthread
In file included from /usr/include/linux/wireless.h:74:0,
                 from hcxdumptool.c:27:
/usr/include/linux/if.h:142:8: error: redefinition of 'struct ifmap'
 struct ifmap {
        ^~~~~
In file included from hcxdumptool.c:17:0:
/usr/include/net/if.h:64:8: note: originally defined here
 struct ifmap {
        ^~~~~
In file included from /usr/include/linux/wireless.h:74:0,
                 from hcxdumptool.c:27:
/usr/include/linux/if.h:176:8: error: redefinition of 'struct ifreq'
 struct ifreq {
        ^~~~~
In file included from hcxdumptool.c:17:0:
/usr/include/net/if.h:76:8: note: originally defined here
 struct ifreq {
        ^~~~~
In file included from /usr/include/linux/wireless.h:74:0,
                 from hcxdumptool.c:27:
/usr/include/linux/if.h:225:8: error: redefinition of 'struct ifconf'
 struct ifconf  {
        ^~~~~~
In file included from hcxdumptool.c:17:0:
/usr/include/net/if.h:116:8: note: originally defined here
 struct ifconf {
        ^~~~~~
```